### PR TITLE
add: allow private access to gpi repository

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+@gpiiltd:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## What

Add npm token environment varible 

## Why

To allow access private repositories
